### PR TITLE
Allow user to mount their own r10k.yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ $ docker run -p 8080:8080 \
              erlend/r10k
 ```
 
+## Custom r10k configurations
+
+To use a customized r10k configuration, mount it to the default location. `GIT_REMOTE` becomes unnecessary at that point.
+
+```
+$ docker run -p 8080:8080 \
+             -e WEBHOOK_SECRET=topsecret \
+             -v ~/.ssh/id_rsa:/home/r10k/.ssh/id_rsa:ro \
+             -v /etc/puppetlabs/r10k/r10k.yaml:/etc/puppetlabs/r10k/r10k.yaml:ro \
+             -v puppet-environments:/etc/puppetlabs/code/environments:rw \
+             erlend/r10k
+```
+

--- a/entrypoint.d/r10k
+++ b/entrypoint.d/r10k
@@ -2,15 +2,17 @@
 
 set -e
 r10k_dir=/etc/puppetlabs/r10k
-
-if [ -z $GIT_REMOTE ]; then
-  echo 'Error: $GIT_REMOTE is undefined'
-  exit 1
-fi
-
-[ -n $DEBUG ] && echo "Configuring R10k to use $GIT_REMOTE"
 mkdir -p $r10k_dir
-cat > $r10k_dir/r10k.yaml <<-EOF
+if [[ -f "${r10k_dir}/r10k.yaml" ]]; then
+  [ -n $DEBUG ] && echo "Using provided R10k configuration"
+else
+  if [ -z $GIT_REMOTE ]; then
+    echo 'Error: $GIT_REMOTE is undefined'
+    exit 1
+  fi
+
+  [ -n $DEBUG ] && echo "Configuring R10k to use $GIT_REMOTE"
+  cat > $r10k_dir/r10k.yaml <<-EOF
 :cachedir: /var/cache/r10k
 
 :sources:
@@ -18,3 +20,4 @@ cat > $r10k_dir/r10k.yaml <<-EOF
     remote: $GIT_REMOTE
     basedir: /etc/puppetlabs/code/environments
 EOF
+fi


### PR DESCRIPTION
This will allow for custom r10k configurations, such as multiple sources and postrun commands.

Defaults to old behavior.