### PR TITLE
Validate the environment to avoid big error

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,10 +8,23 @@ class RunnerJob
 
   def perform(branch)
     return false if branch.to_s == ''
-    command.run(branch: branch)
+    if valid_environment(branch)
+      command.run(branch: branch)
+    else
+      logger.send(:info, 'Ignoring hook for non-existent environment: ' + branch)
+    end
   end
 
   private
+  def valid_environment(branch)
+    get_environments = Cocaine::CommandLine.new(App.settings.r10k_bin, 'deploy display --fetch --format json')
+    environment_json = JSON.load( get_environments.run() )
+    environment_json['sources'].each do |source|
+      return true if source['environments'].include?(branch)
+    end
+    return false
+  end
+
   def command
     r10k_bin = App.settings.r10k_bin
     Cocaine::CommandLine.new(r10k_bin, 'deploy environment -p :branch')


### PR DESCRIPTION
Outputs a single line error if the webhook indicates a branch which doesn't exist in the control repo, instead of the full Exception.